### PR TITLE
Replace manual AST type stitching with go/types

### DIFF
--- a/cmd/breaker-cli/main.go
+++ b/cmd/breaker-cli/main.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"go/ast"
+	"go/types"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"strconv"
-	"strings"
 	"text/template"
 
 	"golang.org/x/tools/go/packages"
@@ -26,7 +24,7 @@ func main() {
 	flag.Parse()
 
 	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedSyntax,
+		Mode: packages.NeedName | packages.NeedTypes,
 	}
 	file, err := packages.Load(cfg, *_package)
 	if err != nil {
@@ -42,98 +40,31 @@ func main() {
 
 	packageName := file[0].Name
 
-	// Extract the interface
-	var interfaces []Interface
-	for ident := range file[0].TypesInfo.Defs {
-		if ident.Name != *_interface {
-			continue
-		}
-		if ident.Obj == nil {
-			continue
-		}
-		if ident.Obj.Kind != ast.Typ {
-			continue
-		}
-		typeSpec, ok := ident.Obj.Decl.(*ast.TypeSpec)
-		if !ok {
-			continue
-		}
-		interfaceType, ok := typeSpec.Type.(*ast.InterfaceType)
-		if !ok {
-			continue
-		}
-
-		var methods []Method
-		for _, method := range interfaceType.Methods.List {
-			methodName := method.Names[0].Name
-			var params, returns []Param
-
-			fieldList, ok := method.Type.(*ast.FuncType)
-			if !ok {
-				continue
-			}
-
-			for i, field := range fieldList.Params.List {
-				paramName := "param" + strconv.Itoa(i)
-				if len(field.Names) > 0 {
-					paramName = field.Names[0].Name
-				}
-				ellipsis := false
-				var _type string
-				switch v := field.Type.(type) {
-				case *ast.Ident:
-					_type = identName(packageName, v)
-				case *ast.StarExpr:
-					_type = starExprName(packageName, v)
-				case *ast.SelectorExpr:
-					_type = selectorExprName(packageName, v)
-				case *ast.ArrayType:
-					_type = arrayTypeName(packageName, v)
-				case *ast.MapType:
-					_type = mapTypeName(packageName, v)
-				case *ast.Ellipsis:
-					ellipsis = true
-					_type = ellipsisName(packageName, v)
-				default:
-					log.Fatalf("unsupported param type: %T", field.Type)
-				}
-				params = append(params, Param{Name: paramName, Type: _type, Ellipsis: ellipsis})
-			}
-			for i, field := range fieldList.Results.List {
-				paramName := "result" + strconv.Itoa(i)
-				if len(field.Names) > 0 {
-					paramName = field.Names[0].Name
-				}
-				var _type string
-				switch v := field.Type.(type) {
-				case *ast.Ident:
-					_type = identName(packageName, v)
-				case *ast.StarExpr:
-					_type = starExprName(packageName, v)
-				case *ast.SelectorExpr:
-					_type = selectorExprName(packageName, v)
-				case *ast.ArrayType:
-					_type = arrayTypeName(packageName, v)
-				case *ast.MapType:
-					_type = mapTypeName(packageName, v)
-				default:
-					log.Fatalf("unsupported return type: %T", field.Type)
-				}
-				returns = append(returns, Param{Name: paramName, Type: _type})
-			}
-
-			methods = append(methods, Method{Name: methodName, Params: params, Results: returns})
-		}
-
-		interfaces = append(interfaces, Interface{Name: ident.Name, Methods: methods})
+	// Extract the interface from the package scope using go/types.
+	obj := file[0].Types.Scope().Lookup(*_interface)
+	if obj == nil {
+		log.Fatalf("interface %q not found in package %s", *_interface, packageName)
+	}
+	iface, ok := obj.Type().Underlying().(*types.Interface)
+	if !ok {
+		log.Fatalf("%q is not an interface", *_interface)
 	}
 
-	if len(interfaces) == 0 {
-		log.Fatalf("no interface found")
+	qualifier := func(p *types.Package) string { return p.Name() }
+
+	var methods []Method
+	for i := range iface.NumMethods() {
+		m := iface.Method(i)
+		sig := m.Type().(*types.Signature)
+
+		params := extractParams(sig.Params(), sig.Variadic(), qualifier)
+		returns := extractResults(sig.Results(), qualifier)
+
+		methods = append(methods, Method{Name: m.Name(), Params: params, Results: returns})
 	}
 
 	// implement Interface
-	implementation := implementInterface(interfaces[0])
+	implementation := implementInterface(Interface{Name: *_interface, Methods: methods})
 
 	// generate code
 	pkg := Package{
@@ -164,113 +95,44 @@ func main() {
 	io.Copy(writer, reader)
 }
 
-func identName(pkg string, t *ast.Ident) string {
-	// TODO: do you have a better way to handle basic types?
+func extractParams(tuple *types.Tuple, variadic bool, qualifier types.Qualifier) []Param {
+	var params []Param
+	for i := range tuple.Len() {
+		v := tuple.At(i)
+		name := v.Name()
+		if name == "" {
+			name = fmt.Sprintf("param%d", i)
+		}
 
-	// basic types
-	switch t.Name {
-	case "int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64",
-		"float32", "float64",
-		"string", "bool", "byte", "rune", "error":
-		return t.Name
+		isVariadic := variadic && i == tuple.Len()-1
+		var typStr string
+		if isVariadic {
+			// For variadic params, the type is a *types.Slice; extract the element type.
+			elem := v.Type().(*types.Slice).Elem()
+			typStr = "..." + types.TypeString(elem, qualifier)
+		} else {
+			typStr = types.TypeString(v.Type(), qualifier)
+		}
+
+		params = append(params, Param{Name: name, Type: typStr, Ellipsis: isVariadic})
 	}
-
-	// package types
-	return pkg + "." + t.Name
+	return params
 }
 
-func ellipsisName(pkg string, t *ast.Ellipsis) string {
-	var name string
-	switch x := t.Elt.(type) {
-	case *ast.Ident:
-		name = identName(pkg, x)
-	case *ast.SelectorExpr:
-		name = selectorExprName(pkg, x)
-	case *ast.StarExpr:
-		name = starExprName(pkg, x)
-	case *ast.ArrayType:
-		name = arrayTypeName(pkg, x)
-	case *ast.MapType:
-		name = mapTypeName(pkg, x)
-	default:
-		panic(fmt.Sprintf("unsupported ellipsis type: %T", x))
+func extractResults(tuple *types.Tuple, qualifier types.Qualifier) []Param {
+	var results []Param
+	for i := range tuple.Len() {
+		v := tuple.At(i)
+		name := v.Name()
+		if name == "" {
+			name = fmt.Sprintf("result%d", i)
+		}
+		results = append(results, Param{
+			Name: name,
+			Type: types.TypeString(v.Type(), qualifier),
+		})
 	}
-	return "..." + name
-}
-
-func selectorExprName(pkg string, t *ast.SelectorExpr) string {
-	switch x := t.X.(type) {
-	case *ast.Ident:
-		return x.Name + "." + t.Sel.Name
-	default:
-		panic(fmt.Sprintf("unsupported selector expr: %T", t))
-	}
-}
-
-func starExprName(pkg string, t *ast.StarExpr) string {
-	var name string
-	switch x := t.X.(type) {
-	case *ast.Ident:
-		name = identName(pkg, x)
-	case *ast.ArrayType:
-		name = arrayTypeName(pkg, x)
-	case *ast.MapType:
-		name = mapTypeName(pkg, x)
-	case *ast.SelectorExpr:
-		name = selectorExprName(pkg, x)
-	default:
-		panic(fmt.Sprintf("unsupported star expr: %T", t))
-	}
-	return "*" + name
-}
-
-func arrayTypeName(pkg string, t *ast.ArrayType) string {
-	var name string
-	switch elt := t.Elt.(type) {
-	case *ast.Ident:
-		name = identName(pkg, elt)
-	case *ast.SelectorExpr:
-		name = selectorExprName(pkg, elt)
-	case *ast.StarExpr:
-		name = starExprName(pkg, elt)
-	case *ast.ArrayType:
-		name = arrayTypeName(pkg, elt)
-	case *ast.MapType:
-		name = mapTypeName(pkg, elt)
-	default:
-		panic(fmt.Sprintf("unsupported array type: %T", elt))
-	}
-	return "[]" + name
-}
-
-func mapTypeName(pkg string, t *ast.MapType) string {
-	var key, value string
-	switch k := t.Key.(type) {
-	case *ast.Ident:
-		key = identName(pkg, k)
-	case *ast.StarExpr:
-		key = starExprName(pkg, k)
-	default:
-		panic(fmt.Sprintf("unsupported map key type: %T", k))
-	}
-
-	switch v := t.Value.(type) {
-	case *ast.Ident:
-		value = identName(pkg, v)
-	case *ast.SelectorExpr:
-		value = selectorExprName(pkg, v)
-	case *ast.StarExpr:
-		value = starExprName(pkg, v)
-	case *ast.ArrayType:
-		value = arrayTypeName(pkg, v)
-	case *ast.MapType:
-		value = mapTypeName(pkg, v)
-	default:
-		panic(fmt.Sprintf("unsupported map value type: %T", v))
-	}
-
-	return fmt.Sprintf("map[%s]%s", key, value)
+	return results
 }
 
 func parseBreakerTemplate() (*template.Template, error) {
@@ -345,7 +207,3 @@ func implementInterface(iface Interface) Struct {
 	}
 }
 
-func toLowerCamelCase(s string) string {
-	firstChar := strings.ToLower(s[:1])
-	return firstChar + s[1:]
-}


### PR DESCRIPTION
## Summary

- Replace ~110 lines of hand-rolled AST type formatters (`identName`, `ellipsisName`, `selectorExprName`, `starExprName`, `arrayTypeName`, `mapTypeName`) with `go/types.TypeString()` and `Scope().Lookup()`
- Simplify `packages.Config` mode from `NeedName|NeedTypes|NeedTypesInfo|NeedSyntax` to `NeedName|NeedTypes`
- Remove dead code: `toLowerCamelCase` and unreachable `len(interfaces) == 0` check

This fixes several limitations of the manual approach:
- Missing support for `interface{}`, `func`, `chan` types
- Incomplete basic type list (missing `any`, `uintptr`, `complex64/128`)
- Multi-name parameters (`a, b int`) only capturing the first name
- Embedded interface methods not being extracted

## Test plan

- [x] `go build .` passes
- [x] `go vet .` passes
- [x] `go test -v .` passes (`TestTemplateValidationPipeline` — parse, generate_and_go_fix, final_build)